### PR TITLE
Require session before editor ready and forward credentials in tRPC client

### DIFF
--- a/src/components/excalidraw/excalidraw-editor.tsx
+++ b/src/components/excalidraw/excalidraw-editor.tsx
@@ -202,7 +202,7 @@ export default function ExcalidrawEditor() {
     uploadSceneToCloud,
     getActiveTheme: () => browserActiveTheme,
     workspaceId: currentWorkspaceId,
-    isReady: !!excalidrawAPI && isSessionReady,
+    isReady: !!excalidrawAPI && isSessionReady && !!session,
     isUploadInProgress: uploadStatus === "uploading",
     isBlockingDialogOpen:
       isSceneChangeDialogOpen || isCloudUploadDialogOpen || workspaceCreateConfirmOpen,

--- a/src/components/excalidraw/published-scene-viewer.tsx
+++ b/src/components/excalidraw/published-scene-viewer.tsx
@@ -68,6 +68,30 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+function getCenteredZoomState(
+  appState: AppState,
+  nextZoom: AppState["zoom"]["value"],
+): Pick<AppState, "scrollX" | "scrollY" | "zoom"> {
+  const viewportCenterX = appState.offsetLeft + appState.width / 2;
+  const viewportCenterY = appState.offsetTop + appState.height / 2;
+  const appLayerX = viewportCenterX - appState.offsetLeft;
+  const appLayerY = viewportCenterY - appState.offsetTop;
+  const currentZoom = appState.zoom.value;
+  const baseScrollX = appState.scrollX + appLayerX - appLayerX / currentZoom;
+  const baseScrollY = appState.scrollY + appLayerY - appLayerY / currentZoom;
+  const zoomOffsetScrollX = -(appLayerX - appLayerX / nextZoom);
+  const zoomOffsetScrollY = -(appLayerY - appLayerY / nextZoom);
+
+  return {
+    scrollX: baseScrollX + zoomOffsetScrollX,
+    scrollY: baseScrollY + zoomOffsetScrollY,
+    zoom: {
+      ...appState.zoom,
+      value: nextZoom,
+    },
+  };
+}
+
 const ICON_BTN =
   "inline-flex h-10 w-10 items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
 
@@ -236,13 +260,15 @@ export function PublishedSceneViewer({
       if (!excalidrawAPI) return;
       const current = excalidrawAPI.getAppState();
       const nextZoom = clamp(current.zoom.value * factor, MIN_ZOOM, MAX_ZOOM);
+      if (nextZoom === current.zoom.value) return;
+
       excalidrawAPI.updateScene({
         appState: {
           ...current,
-          zoom: {
-            ...current.zoom,
-            value: nextZoom as AppState["zoom"]["value"],
-          },
+          ...getCenteredZoomState(
+            current,
+            nextZoom as AppState["zoom"]["value"],
+          ),
         },
       });
     },

--- a/src/components/excalidraw/published-scene-viewer.tsx
+++ b/src/components/excalidraw/published-scene-viewer.tsx
@@ -69,7 +69,10 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 const ICON_BTN =
-  "rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+  "inline-flex h-[44px] w-[44px] items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+
+const TEXT_BTN =
+  "inline-flex h-[44px] min-w-[44px] items-center justify-center rounded-md px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
 
 export function PublishedSceneViewer({
   sceneData,
@@ -280,15 +283,15 @@ export function PublishedSceneViewer({
     <div className="published-viewer flex h-full w-full flex-col">
       {/* ── Header ── */}
       {uiVisible && (
-        <header className="border-border bg-background flex h-12 shrink-0 items-center justify-between border-b px-3 sm:px-5">
-          <Link href="/" className="flex items-center gap-1.5 px-2">
+        <header className="border-border bg-background flex h-12 shrink-0 items-center justify-between gap-2 border-b px-3 sm:px-5">
+          <Link href="/" className="flex shrink-0 items-center gap-1.5 px-2">
             <DrawstuffLogo className="h-4 w-4 text-indigo-500 dark:text-gray-300" />
             <span className="hidden text-lg font-medium sm:inline">
               drawstuff
             </span>
           </Link>
 
-          <div className="flex min-w-0 items-center gap-2 px-4">
+          <div className="flex min-w-0 flex-1 items-center justify-center gap-2 px-2">
             <h1 className="truncate text-sm font-medium sm:text-base">
               {sceneName}
             </h1>
@@ -302,7 +305,47 @@ export function PublishedSceneViewer({
             )}
           </div>
 
-          <div className="flex items-center gap-0.5">
+          <div className="flex shrink-0 items-center gap-0.5">
+            <div className="hidden items-center gap-0.5 sm:flex">
+              <button
+                type="button"
+                onClick={() => zoomBy(1 / ZOOM_STEP)}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.zoomOut")}
+                title={t("public.viewer.zoomOut")}
+              >
+                <ZoomOut className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => zoomBy(ZOOM_STEP)}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.zoomIn")}
+                title={t("public.viewer.zoomIn")}
+              >
+                <ZoomIn className="h-4 w-4" />
+              </button>
+              <div className="bg-border mx-1 h-4 w-px" />
+              <button
+                type="button"
+                onClick={fitToScreen}
+                className={TEXT_BTN}
+                aria-label={t("public.viewer.fit")}
+                title={t("public.viewer.fit")}
+              >
+                {t("public.viewer.fit")}
+              </button>
+              <button
+                type="button"
+                onClick={resetView}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.reset")}
+                title={t("public.viewer.reset")}
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </button>
+              <div className="bg-border mx-1 h-4 w-px" />
+            </div>
             <button
               type="button"
               onClick={toggleTheme}
@@ -336,7 +379,7 @@ export function PublishedSceneViewer({
           <button
             type="button"
             onClick={() => setUiVisible(true)}
-            className="border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground absolute right-3 bottom-3 z-10 rounded-md border p-2 shadow-sm transition-colors sm:right-4 sm:bottom-4"
+            className={`${ICON_BTN} border-border bg-background absolute top-3 right-3 z-10 border shadow-sm sm:top-4 sm:right-4`}
             aria-label={t("public.viewer.showUI")}
             title={t("public.viewer.showUI")}
           >
@@ -426,44 +469,6 @@ export function PublishedSceneViewer({
           </div>
         )}
       </div>
-
-      {/* ── Bottom toolbar ── */}
-      {uiVisible && (
-        <div className="border-border bg-background hidden h-10 shrink-0 items-center justify-center gap-1 border-t sm:flex">
-          <button
-            type="button"
-            onClick={() => zoomBy(1 / ZOOM_STEP)}
-            className={ICON_BTN}
-            aria-label={t("public.viewer.zoomOut")}
-          >
-            <ZoomOut className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => zoomBy(ZOOM_STEP)}
-            className={ICON_BTN}
-            aria-label={t("public.viewer.zoomIn")}
-          >
-            <ZoomIn className="h-4 w-4" />
-          </button>
-          <div className="bg-border mx-1 h-4 w-px" />
-          <button
-            type="button"
-            onClick={fitToScreen}
-            className="text-muted-foreground hover:bg-muted hover:text-foreground rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors"
-          >
-            {t("public.viewer.fit")}
-          </button>
-          <button
-            type="button"
-            onClick={resetView}
-            className={ICON_BTN}
-            aria-label={t("public.viewer.reset")}
-          >
-            <RefreshCw className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/excalidraw/published-scene-viewer.tsx
+++ b/src/components/excalidraw/published-scene-viewer.tsx
@@ -11,7 +11,7 @@ import {
   ZoomIn,
   ZoomOut,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   BinaryFileData,
   BinaryFiles,
@@ -114,6 +114,10 @@ export function PublishedSceneViewer({
     useState<ExcalidrawImperativeAPI | null>(null);
   const [hasAutoCentered, setHasAutoCentered] = useState(false);
   const [uiVisible, setUiVisible] = useState(true);
+  const headerRef = useRef<HTMLElement | null>(null);
+  const headerLeftRef = useRef<HTMLAnchorElement | null>(null);
+  const headerRightRef = useRef<HTMLDivElement | null>(null);
+  const [titleMaxWidth, setTitleMaxWidth] = useState<number | undefined>();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -250,6 +254,33 @@ export function PublishedSceneViewer({
     };
   }, [excalidrawAPI, hasAutoCentered, initialData]);
 
+  useEffect(() => {
+    if (!uiVisible) return;
+
+    const updateTitleMaxWidth = () => {
+      const headerWidth = headerRef.current?.getBoundingClientRect().width ?? 0;
+      const leftWidth =
+        headerLeftRef.current?.getBoundingClientRect().width ?? 0;
+      const rightWidth =
+        headerRightRef.current?.getBoundingClientRect().width ?? 0;
+      const sideWidth = Math.max(leftWidth, rightWidth);
+      const horizontalPadding = 24;
+
+      setTitleMaxWidth(
+        Math.max(0, headerWidth - sideWidth * 2 - horizontalPadding),
+      );
+    };
+
+    updateTitleMaxWidth();
+
+    const observer = new ResizeObserver(updateTitleMaxWidth);
+    if (headerRef.current) observer.observe(headerRef.current);
+    if (headerLeftRef.current) observer.observe(headerLeftRef.current);
+    if (headerRightRef.current) observer.observe(headerRightRef.current);
+
+    return () => observer.disconnect();
+  }, [uiVisible]);
+
   const fitToScreen = useCallback(() => {
     if (!excalidrawAPI) return;
     excalidrawAPI.scrollToContent(undefined, FIT_TO_VIEWPORT_OPTIONS);
@@ -309,29 +340,44 @@ export function PublishedSceneViewer({
     <div className="published-viewer flex h-full w-full flex-col">
       {/* ── Header ── */}
       {uiVisible && (
-        <header className="border-border bg-background flex h-12 shrink-0 items-center justify-between gap-2 border-b px-3 sm:px-5">
-          <Link href="/" className="flex shrink-0 items-center gap-1.5 px-2">
+        <header
+          ref={headerRef}
+          className="border-border bg-background relative flex h-12 shrink-0 items-center justify-between gap-2 border-b px-3 sm:px-5"
+        >
+          <Link
+            ref={headerLeftRef}
+            href="/"
+            className="z-10 flex shrink-0 items-center gap-1.5 px-2"
+          >
             <DrawstuffLogo className="h-4 w-4 text-indigo-500 dark:text-gray-300" />
             <span className="hidden text-lg font-medium sm:inline">
               drawstuff
             </span>
           </Link>
 
-          <div className="flex min-w-0 flex-1 items-center justify-center gap-2 px-2">
-            <h1 className="truncate text-sm font-medium sm:text-base">
+          <div
+            className="pointer-events-none absolute left-1/2 flex max-w-[calc(100vw-8rem)] min-w-0 -translate-x-1/2 items-center justify-center gap-2 px-2 sm:max-w-[40vw]"
+            style={{ maxWidth: titleMaxWidth }}
+          >
+            <h1 className="min-w-0 truncate text-sm font-medium sm:text-base">
               {sceneName}
             </h1>
             {authorName && (
-              <div className="hidden space-x-1 sm:inline">
-                <span className="text-muted-foreground text-xs">·</span>
-                <span className="text-muted-foreground text-xs">
+              <div className="hidden min-w-0 items-center gap-1 sm:flex">
+                <span className="text-muted-foreground shrink-0 text-xs">
+                  ·
+                </span>
+                <span className="text-muted-foreground min-w-0 truncate text-xs">
                   {authorName}
                 </span>
               </div>
             )}
           </div>
 
-          <div className="flex shrink-0 items-center gap-0.5">
+          <div
+            ref={headerRightRef}
+            className="z-10 flex shrink-0 items-center gap-0.5"
+          >
             <div className="hidden items-center gap-0.5 sm:flex">
               <button
                 type="button"

--- a/src/components/excalidraw/published-scene-viewer.tsx
+++ b/src/components/excalidraw/published-scene-viewer.tsx
@@ -69,10 +69,10 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 const ICON_BTN =
-  "inline-flex h-[44px] w-[44px] items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+  "inline-flex h-10 w-10 items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
 
 const TEXT_BTN =
-  "inline-flex h-[44px] min-w-[44px] items-center justify-center rounded-md px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+  "inline-flex h-10 min-w-10 items-center justify-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
 
 export function PublishedSceneViewer({
   sceneData,

--- a/src/components/excalidraw/published-scene-viewer.tsx
+++ b/src/components/excalidraw/published-scene-viewer.tsx
@@ -5,6 +5,7 @@ import { Excalidraw, MainMenu, restore } from "@excalidraw/excalidraw";
 import {
   Eye,
   EyeOff,
+  Menu,
   Moon,
   RefreshCw,
   Sun,
@@ -98,6 +99,9 @@ const ICON_BTN =
 const TEXT_BTN =
   "inline-flex h-10 min-w-10 items-center justify-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
 
+const CONTROLS_MENU =
+  "border-border bg-background/95 absolute top-[calc(100%+0.5rem)] right-0 z-20 flex origin-top-right flex-col items-center gap-0.5 rounded-md border p-1 shadow-sm backdrop-blur transition-[opacity,transform] duration-150 ease-out will-change-transform motion-reduce:transition-none";
+
 export function PublishedSceneViewer({
   sceneData,
   fileRecords,
@@ -114,6 +118,7 @@ export function PublishedSceneViewer({
     useState<ExcalidrawImperativeAPI | null>(null);
   const [hasAutoCentered, setHasAutoCentered] = useState(false);
   const [uiVisible, setUiVisible] = useState(true);
+  const [controlsMenuOpen, setControlsMenuOpen] = useState(false);
   const headerRef = useRef<HTMLElement | null>(null);
   const headerLeftRef = useRef<HTMLAnchorElement | null>(null);
   const headerRightRef = useRef<HTMLDivElement | null>(null);
@@ -281,6 +286,36 @@ export function PublishedSceneViewer({
     return () => observer.disconnect();
   }, [uiVisible]);
 
+  useEffect(() => {
+    if (!uiVisible) {
+      setControlsMenuOpen(false);
+    }
+  }, [uiVisible]);
+
+  useEffect(() => {
+    if (!controlsMenuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!headerRightRef.current?.contains(event.target as Node)) {
+        setControlsMenuOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setControlsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [controlsMenuOpen]);
+
   const fitToScreen = useCallback(() => {
     if (!excalidrawAPI) return;
     excalidrawAPI.scrollToContent(undefined, FIT_TO_VIEWPORT_OPTIONS);
@@ -376,9 +411,93 @@ export function PublishedSceneViewer({
 
           <div
             ref={headerRightRef}
-            className="z-10 flex shrink-0 items-center gap-0.5"
+            className="relative z-10 flex shrink-0 items-center gap-0.5"
           >
-            <div className="hidden items-center gap-0.5 sm:flex">
+            <button
+              type="button"
+              onClick={() => setControlsMenuOpen((open) => !open)}
+              className={`${ICON_BTN} lg:hidden`}
+              aria-label="Menu"
+              aria-controls="published-viewer-controls-menu"
+              aria-expanded={controlsMenuOpen}
+              title="Menu"
+            >
+              <Menu className="h-4 w-4" />
+            </button>
+
+            <div
+              id="published-viewer-controls-menu"
+              className={`${CONTROLS_MENU} lg:hidden ${
+                controlsMenuOpen
+                  ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
+                  : "pointer-events-none -translate-y-1 scale-95 opacity-0"
+              }`}
+              aria-hidden={!controlsMenuOpen}
+              inert={!controlsMenuOpen}
+            >
+              <button
+                type="button"
+                onClick={() => zoomBy(1 / ZOOM_STEP)}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.zoomOut")}
+                title={t("public.viewer.zoomOut")}
+              >
+                <ZoomOut className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => zoomBy(ZOOM_STEP)}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.zoomIn")}
+                title={t("public.viewer.zoomIn")}
+              >
+                <ZoomIn className="h-4 w-4" />
+              </button>
+              <div className="bg-border my-1 h-px w-4" />
+              <button
+                type="button"
+                onClick={fitToScreen}
+                className={TEXT_BTN}
+                aria-label={t("public.viewer.fit")}
+                title={t("public.viewer.fit")}
+              >
+                {t("public.viewer.fit")}
+              </button>
+              <button
+                type="button"
+                onClick={resetView}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.reset")}
+                title={t("public.viewer.reset")}
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </button>
+              <div className="bg-border my-1 h-px w-4" />
+              <button
+                type="button"
+                onClick={toggleTheme}
+                className={ICON_BTN}
+                aria-label={themeLabel}
+                title={themeLabel}
+              >
+                {browserActiveTheme === "light" ? (
+                  <Sun className="h-4 w-4" />
+                ) : (
+                  <Moon className="h-4 w-4" />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => setUiVisible(false)}
+                className={ICON_BTN}
+                aria-label={t("public.viewer.hideUI")}
+                title={t("public.viewer.hideUI")}
+              >
+                <EyeOff className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="hidden items-center gap-0.5 lg:flex">
               <button
                 type="button"
                 onClick={() => zoomBy(1 / ZOOM_STEP)}
@@ -418,28 +537,6 @@ export function PublishedSceneViewer({
               </button>
               <div className="bg-border mx-1 h-4 w-px" />
             </div>
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className={ICON_BTN}
-              aria-label={themeLabel}
-              title={themeLabel}
-            >
-              {browserActiveTheme === "light" ? (
-                <Sun className="h-4 w-4" />
-              ) : (
-                <Moon className="h-4 w-4" />
-              )}
-            </button>
-            <button
-              type="button"
-              onClick={() => setUiVisible(false)}
-              className={ICON_BTN}
-              aria-label={t("public.viewer.hideUI")}
-              title={t("public.viewer.hideUI")}
-            >
-              <EyeOff className="h-4 w-4" />
-            </button>
           </div>
         </header>
       )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,6 +5,13 @@
 @custom-variant dark (&:is(.dark *));
 @source "../../node_modules/@uploadthing/react/dist";
 
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 @keyframes flash-once {
   0% {
     opacity: 0.2;

--- a/src/trpc/client.ts
+++ b/src/trpc/client.ts
@@ -9,6 +9,11 @@ function createClient() {
       httpBatchStreamLink({
         transformer: SuperJSON,
         url: getBaseUrl() + "/api/trpc",
+        fetch: (url, options) =>
+          fetch(url, {
+            ...options,
+            credentials: "include",
+          }),
       }),
     ],
   });


### PR DESCRIPTION
## Summary
- Gate `ExcalidrawEditor` readiness on an active `session` by changing `isReady` to include `!!session`.
- Update tRPC client to use a custom `fetch` with `credentials: "include"`, ensuring cookies/session headers are sent with all tRPC HTTP batch requests.
- This reduces premature editor usage before auth/session initialization and aligns backend calls with authenticated session context.

## Testing
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication session validation for editor functionality
  * Improved API request credential handling to ensure secure communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->