### PR TITLE
Refactor workspace-dropdown cast usage

### DIFF
--- a/src/components/workspace-dropdown.tsx
+++ b/src/components/workspace-dropdown.tsx
@@ -161,12 +161,13 @@ function WorkspaceDropdownComponent(
           ? await onCreate(name)
           : await createWorkspaceMutation.mutateAsync({ name });
         if (created?.id) {
-          setSelectedWorkspace(created as Workspace);
+          const createdWorkspace: Workspace = created;
+          setSelectedWorkspace(createdWorkspace);
           setPendingCreatedName(undefined);
           if (onCreateSuccess) {
-            onCreateSuccess(created as Workspace);
+            onCreateSuccess(createdWorkspace);
           } else {
-            onChange?.(created as Workspace);
+            onChange?.(createdWorkspace);
           }
         } else if (onCreate) {
           setSelectedWorkspace(undefined);


### PR DESCRIPTION
## Summary
- Replaced repeated `created as Workspace` assertions in `WorkspaceDropdownComponent` with a typed local variable: `const createdWorkspace: Workspace = created;`.
- Reused `createdWorkspace` for `setSelectedWorkspace`, `onCreateSuccess`, and `onChange` calls to avoid duplicate casting and improve readability.
- Behavior remains unchanged; this is a type-focused cleanup in `src/components/workspace-dropdown.tsx`.

## Testing
- Not run (type/style-only refactor, no functional changes expected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined workspace creation handling to use a single created workspace value consistently across follow-up actions.
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->